### PR TITLE
Update class-gumlet.php to exclude image processing with fetchpriority="high" attribute

### DIFF
--- a/includes/class-gumlet.php
+++ b/includes/class-gumlet.php
@@ -564,7 +564,7 @@ class Gumlet
                 $imageTag->setAttribute("data-gmlazy", 'false');
             }
 
-            if (in_array($src, $excluded_urls)) {
+            if (in_array($src, $excluded_urls) || strpos($imageTag->getAttribute('fetchpriority'), "high") !== false) {
                 // don't process excluded URLs
                 $imageTag->setAttribute("data-gumlet", 'false');
                 $new_img_tag = $doc->saveHTML($imageTag);


### PR DESCRIPTION
Skip processing images with fetchpriority="high" specified on the <img> tag to reduce LCP (Google Core Web Vitals).

Use case: If the image is visible within the viewport upon loading, using Gumlet to lazy load the image would increase the LCP considerably. By placing fetchpriority="high" within the image tag and without Gumlet, 

`<img src="..." fetchpriority="high" />`

the browser will load the image as soon as possible, leading to a marked improvement in LCP (in my test case from 4.6s to 2.1s).

Reference: [https://web.dev/priority-hints/](https://web.dev/priority-hints/)