### PR TITLE
Handle missing source tag in replace_srcset_in_source

### DIFF
--- a/includes/class-gumlet.php
+++ b/includes/class-gumlet.php
@@ -653,6 +653,11 @@ class Gumlet
             //write function to remove srcset for img and this function.
             @$doc->loadHTML($source_tag);
             $sourceTag = $doc->getElementsByTagName('source')[0];
+            if (!$sourceTag) {
+                $this->logger->log("No source tag found in HTML");
+                continue;
+            }
+
             $src = $sourceTag->getAttribute('srcset');
             $sourceTag->removeAttribute("srcset");
             $sourceTag->setAttribute("data-srcset", $src);


### PR DESCRIPTION
If it happens that `$sourceTag` variable is null, then error is thrown

`PHP message: PHP Fatal error:  Uncaught Error: Call to a member function getAttribute() on null in ../plugins/gumlet/includes/class-gumlet.php:656`